### PR TITLE
Update install packages section in visual_studio_win_example.rst

### DIFF
--- a/docs/DevelopmentSetup/visual_studio_win_example.rst
+++ b/docs/DevelopmentSetup/visual_studio_win_example.rst
@@ -25,7 +25,7 @@ Start a command shell in the Vcpkg repository folder (that you had cloned earlie
     bootstrap-vcpkg.bat
 
     # install packages
-    vcpkg.exe install boost-test:x64-windows boost-program-options:x64-windows boost-log:x64-windows turtle:x64-windows zipper:x64-windows poco:x64-windows libpq:x64-windows gdal:x64-windows sqlite3:x64-windows boost-ublas:x64-windows fmt:x64-windows
+    vcpkg.exe install boost-test:x64-windows boost-program-options:x64-windows boost-log:x64-windows turtle:x64-windows zipper:x64-windows poco:x64-windows libpq:x64-windows gdal:x64-windows sqlite3:x64-windows boost-ublas:x64-windows fmt:x64-windows libpqxx:x64-windows
 
 .. figure:: ../images/installation_vs2019_flint.example/Step1b.png
   :width: 600


### PR DESCRIPTION
## Description

Added libpqxx:x64-windows library in install packages section as it is required by the GCBM build environment and the users would not need to install it separately while working on GCBM.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
