### PR TITLE
Add extra libraries in windows_installation.rst

### DIFF
--- a/docs/DevelopmentSetup/windows_installation.rst
+++ b/docs/DevelopmentSetup/windows_installation.rst
@@ -27,7 +27,7 @@ Start a command shell in the Vcpkg repository folder (that you had cloned earlie
     bootstrap-vcpkg.bat
 
     # install packages
-    vcpkg.exe install boost-test:x64-windows boost-program-options:x64-windows boost-log:x64-windows turtle:x64-windows zipper:x64-windows poco:x64-windows libpq:x64-windows gdal:x64-windows sqlite3:x64-windows boost-ublas:x64-windows
+    vcpkg.exe install boost-test:x64-windows boost-program-options:x64-windows boost-log:x64-windows turtle:x64-windows zipper:x64-windows poco:x64-windows libpq:x64-windows gdal:x64-windows sqlite3:x64-windows boost-ublas:x64-windows fmt:x64-windows libpqxx:x64-windows
 
 .. figure:: ../images/installation_vs2019_flint.example/Step1b.png
   :width: 600


### PR DESCRIPTION
Update install packages section with extra libraries fmt:x64-windows libpqxx:x64-windows which are required by FLINT.Example and GCBM build environments.

## Description

This PR updates the install packages section with libraries to prevent issues like [this issue](https://github.com/moja-global/moja.canada/issues/17).

### Fixes 
Inconsistencies in the documentation.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
